### PR TITLE
Add quiet mode to disable internal output and log prefixing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.14'
+        go-version: '1.22'
     - name: Build
       run: make "VERSION=${BUILD_TAG}" build
     - name: Version

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,15 @@
 module github.com/ddollar/forego
 
-go 1.14
+go 1.22
 
 require (
 	github.com/daviddengcn/go-colortext v1.0.0
-	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/subosito/gotenv v1.2.0
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
+)
+
+require (
+	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 )

--- a/outlet.go
+++ b/outlet.go
@@ -64,7 +64,9 @@ func (of *OutletFactory) LineReader(wg *sync.WaitGroup, name string, index int, 
 }
 
 func (of *OutletFactory) SystemOutput(str string) {
-	of.WriteLine("forego", str, ct.White, ct.None, false)
+	if !flagQuiet {
+		of.WriteLine("forego", str, ct.White, ct.None, false)
+	}
 }
 
 func (of *OutletFactory) ErrorOutput(str string) {
@@ -77,10 +79,12 @@ func (of *OutletFactory) WriteLine(left, right string, leftC, rightC ct.Color, i
 	of.Lock()
 	defer of.Unlock()
 
-	if colorize {
-		ct.ChangeColor(leftC, true, ct.None, false)
+	if !flagQuiet {
+		if colorize {
+			ct.ChangeColor(leftC, true, ct.None, false)
+		}
+		fmt.Printf(of.LeftFormatter, left)
 	}
-	fmt.Printf(of.LeftFormatter, left)
 
 	if colorize {
 		if isError {

--- a/start.go
+++ b/start.go
@@ -21,6 +21,7 @@ const defaultShutdownGraceTime = 3
 var flagPort int
 var flagConcurrency string
 var flagRestart bool
+var flagQuiet bool
 var flagShutdownGraceTime int
 var envs envFiles
 var colorize bool
@@ -56,6 +57,10 @@ The following options are available:
   -r           Restart a process which exits. Without this, if a process exits,
                forego will kill all other processes and exit.
 
+  -q           Enable quiet mode. This disables printing of internal non-error
+               messages and disables prefixing the process name to stdout and
+               stderr log output.
+
   -t shutdown_grace_time
                Set the shutdown grace time that each process is given after
                being asked to stop. Once this grace time expires, the process is
@@ -89,6 +94,7 @@ func init() {
 	cmdStart.Flag.StringVar(&flagConcurrency, "c", "", "concurrency")
 	cmdStart.Flag.BoolVar(&flagRestart, "r", false, "restart")
 	cmdStart.Flag.IntVar(&flagShutdownGraceTime, "t", defaultShutdownGraceTime, "shutdown grace time")
+	cmdStart.Flag.BoolVar(&flagQuiet, "q", false, "quiet")
 	err := readConfigFile(".forego", &flagProcfile, &flagPort, &flagConcurrency, &flagShutdownGraceTime)
 	handleError(err)
 	colorize = os.Getenv("NO_COLOR") == "" && terminal.IsTerminal(int(os.Stdout.Fd()))


### PR DESCRIPTION
Adds a `-q` option to the start command to disable prefixing log output with the name of the process. If the option is specified, the raw output from stdout and stderr from each application will pass through unchanged. It also disables logging of forego's internal messages at startup.

Default output without the new option:

```
$ ./forego start -f fixtures/multiline/Procfile 
forego    | starting stdout1.1 on port 5000
forego    | starting stdout2.1 on port 5100
stdout1.1 | a
stdout2.1 | a
stdout1.1 | a
stdout1.1 | b
stdout2.1 | a
stdout2.1 | b
stdout1.1 | a
stdout1.1 | b
stdout1.1 | c
stdout2.1 | a
stdout2.1 | b
stdout2.1 | c
stdout1.1 | a
stdout1.1 | b
stdout1.1 | c
stdout1.1 | d
stdout2.1 | a
stdout2.1 | b
stdout2.1 | c
stdout2.1 | d
stdout1.1 | finish!
forego    | sending SIGTERM to stdout2.1
```

Output with the new options:

```
$ ./forego start -f fixtures/multiline/Procfile -q
a
a
a
b
a
b
a
b
c
a
b
c
a
b
c
d
a
b
c
d
finish!
finish!
```

Main usage for this would be to allow structured log output (e.g., JSON) to pass through and still be parseable. It would be left to the applications to be able to differentiate the outputs, for example by adding a `"proc": "foo"` field to the log output itself.