### PR TITLE
Replace x/crypto dep with x/term

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,10 @@ go 1.22
 require (
 	github.com/daviddengcn/go-colortext v1.0.0
 	github.com/subosito/gotenv v1.2.0
-	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 )
 
 require (
 	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
-	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 )

--- a/start.go
+++ b/start.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 const defaultPort = 5000
@@ -97,7 +97,7 @@ func init() {
 	cmdStart.Flag.BoolVar(&flagQuiet, "q", false, "quiet")
 	err := readConfigFile(".forego", &flagProcfile, &flagPort, &flagConcurrency, &flagShutdownGraceTime)
 	handleError(err)
-	colorize = os.Getenv("NO_COLOR") == "" && terminal.IsTerminal(int(os.Stdout.Fd()))
+	colorize = os.Getenv("NO_COLOR") == "" && term.IsTerminal(int(os.Stdout.Fd()))
 }
 
 func readConfigFile(config_path string, flagProcfile *string, flagPort *int, flagConcurrency *string, flagShutdownGraceTime *int) error {


### PR DESCRIPTION
Replace our only usage of x/crypto with direct usage of x/term as the only function we invoke is a pass through to the isTerminal(...) function. This allows us to remove x/crypto as a dep entirely.